### PR TITLE
Add a --date filter and some other quality-of-life improvements to the generated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ The following command will search for Instagram locations nearby the coordinates
 
 Note that this requires an Instagram session ID in order to work! See below for how to obtain one from your account.
 
+## Example usage with date
+
+The following command will search for Instagram locations near Seattle's "Capitol Hill Autonomous Zone" during the George Floyd
+protests in early June, 2020. Not all location pages in the area will have posts relevant to the Zone, but some do. Open the
+resulting `map.html` file in your browser to view locations.
+
+```python3 instagram-locations.py --session "<session-id-token>" --lat 47.6164311 --lng -122.3203952 --map map.html --date 2020-06-09```
+
+When using the `--date` argument, links to Instagram location pages will be filtered to show posts created on this date or earlier.
+Instagram will usually first show a 3x3 grid of "Top Images and Videos" that are more recent, however once you scroll past that
+there is a section labeled "Most recent" which will show the posts sorted by date (if any).
+These links are only used together with the `--csv` and `--map` arguments, they aren't included in `--json` or `--geojson`.
+Note: Instagram treats these dates as "UTC", which is a timezone near Great Britain. If your target location is far from this zone,
+it's worth adding a couple of days to your filter to make sure you capture all relevant posts. Also, this only specifies the
+*maximum* post date that can be displayed. If nothing was posted that day at that location, it will show older posts (sometimes
+even multiple years older).
+
 ### Other output formats
 
 Using the `--json <output-location>` command line argument, the list can be saved as a JSON file, almost identical to the raw API response.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-This Python application requires `requests` and `numpy` to be properly installed. This can be done with `pip3 install requests numpy`.
+This Python application requires `requests`, `numpy`, and `pandas` to be properly installed. This can be done with `pip3 install requests numpy pandas`.
 
 ## Example usage
 

--- a/instagram-locations.py
+++ b/instagram-locations.py
@@ -124,7 +124,7 @@ html_template = '''<html>
       }).addTo(map);
 
       function onEachFeature(feature, layer) {
-        layer.bindPopup(`<a href="https://www.instagram.com/explore/locations/` + feature.properties.external_id + `$date_var">` + feature.properties.name + `</a><br />` + feature.properties.address );
+        layer.bindPopup(`<a href="https://www.instagram.com/explore/locations/` + feature.properties.external_id + `$date_var" target="_blank">` + feature.properties.name + `</a><br />` + feature.properties.address );
       }
 
       L.geoJSON(locs, {

--- a/instagram-locations.py
+++ b/instagram-locations.py
@@ -102,6 +102,10 @@ html_template = '''<html>
         width: 100%;
         height: 600px;
       }
+      img.selected-location {
+        filter: hue-rotate(120deg);
+        z-index: 999 !important;
+      }
     </style>
   </head>
   <body>
@@ -126,6 +130,9 @@ html_template = '''<html>
       L.geoJSON(locs, {
         onEachFeature: onEachFeature
       }).addTo(map);
+
+      var centerMarker = L.marker([$lat, $lng]).addTo(map);
+      centerMarker._icon.classList.add('selected-location');
     </script>
   </body>
 </html>'''


### PR DESCRIPTION
Hi, thanks for the useful tool! I had some small ideas for improvement that I've packed into four commits in case you find them useful, too.

1. The script requires `pandas`, but it was not listed in the pip commands in the README. I've added it to the docs.
2. I added a `--date` argument to the script to append a date filter to the `--csv` and `--map` URLs, which (when loaded in the browser) will only show posts older than the given date. It uses something similar to [this algorithm](https://medium.com/@chrisbenevento/how-to-search-instagram-geotags-for-historical-photos-bb00be3449ca) (I can't find where I originally got the algorithm from) to calculate the proper ID number. To give a concrete use case, you could search for the location of the "Capitol Hill Autonomous Zone" in Seattle in early June 2020 during the George Floyd protests. This will bring up locations with photos of the Zone while it was "occupied", even though that date was many months in the past now.
3. I added a pink map marker to the map view that represents the original searched lat/lon so it's easier to orient yourself if you're browsing a map where you don't know the location well.
4. URLs on the map markers now always open in a new tab if you single-click on one instead of navigating away from the map page itself.