### PR TITLE
ids output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Using the `--json <output-location>` command line argument, the list can be save
 
 Using the `--geojson <output-location>` command line argument, the list can be saved as a GeoJSON file for other geospatial applications.
 
+Using the `--ids <output-location>` command line argument, all the found location IDs are output, suitable to pass into another tool, like [instagram-scraper](https://github.com/arc298/instagram-scraper).
+
 Using the `--map <output-location>` command line argument, a simple Leaflet map is made to visualize the locations of the returned points.
 
 ![Example of map visualization](docs/map-example.png)
@@ -42,6 +44,33 @@ Using the `--map <output-location>` command line argument, a simple Leaflet map 
 Multiple types of output can be generated. For example, the following command will search for Instagram locations, save the JSON list, a CSV file, and a map for viewing the locations visually.
 
 ```python3 instagram-locations.py --session "3888090946%3AhdKd2fA8d72dqD%3A16" --lat 32.22 --lng -110.97 --json locs.json --csv locs.csv --map map.html```
+
+## Sample Usage with `instagram-scraper`
+The ID list generated with the `--ids` flag can be passed into `instagram-scraper` to pull down image metadata.
+
+### :rotating_light: Undocumented API :rotating_light:
+`instagram-scraper` relies on an undocumented API for the mobile apps. YMMV.
+
+First, get the proximal location IDs of your target location:
+```sh
+python3 instagram-locations.py --session "<session-id-token>" --lat <lat> --lng <lng> --ids location_ids.txt
+```
+
+Be sure to install `instagram-scraper`:
+```
+pip install instagram-scraper
+```
+
+Location scraping requires an authenticated request. Save your creds in a local file:
+```sh
+echo "-u=<your username>" >> creds.txt
+echo "-p=<your password>" >> creds.txt
+```
+
+Now use `instagram-scraper` to pull down all the photos at those locations:
+```sh
+instagram-scraper @creds.txt --filename @location_ids.txt --location --include-location --destination <output dir>
+```
 
 ## Getting an Instagram session ID
 

--- a/instagram-locations.py
+++ b/instagram-locations.py
@@ -147,6 +147,7 @@ def main():
     parser.add_argument("--lat", action="store", dest="lat")
     parser.add_argument("--lng", action="store", dest="lng")
     parser.add_argument("--date", action="store", dest="date")
+    parser.add_argument("--ids", action="store", dest="dump_ids")
 
     args = parser.parse_args()
 
@@ -176,7 +177,11 @@ def main():
         df = pd.DataFrame(locations)
         df['url'] = df['external_id'].apply(lambda v: 'https://www.instagram.com/explore/locations/' + str(v) + date_var)
         df.to_csv(args.csv)
+    
+    if (args.dump_ids):
+      ids = map(lambda loc: str(loc['external_id']), locations)
+      with open(args.dump_ids, 'w') as f:
+        f.write('\n'.join(ids))
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
this patch adds a flag for `--ids` which dumps the `external_id` value of all the discovered locations into a given output file. The IDs are new line delimited.

Based on #2 , I kicked the tires on [`instagram-scraper`](https://github.com/arc298/instagram-scraper) and found it to be spotty but perhaps good enough for a first go. It relies on an undocumented API in use by the mobile apps, and from what I can tell FB locks it down at the first sign of abuse.

Based on [some](https://github.com/arc298/instagram-scraper/issues/231#issuecomment-392605308) [threads](https://github.com/arc298/instagram-scraper/issues/208) over at `instagram-scraper`, it seems like people are getting around the limits by throttling their own requests or rotating IPs via proxy, but it doesn't seem like a bullet proof approach has bubbled up.

closes #2 