### PR TITLE
utf-8 encoding

### DIFF
--- a/instagram_locations/instagram_locations.py
+++ b/instagram_locations/instagram_locations.py
@@ -247,7 +247,7 @@ def main():
         # leading empty string for 'id' column is for backward compatibility since that's the pandas behavior.
         fieldnames = ["", "name", "external_id", "external_id_source", "lat", "lng", "address", "minimum_age", "url"]
 
-        with open(args.csv, "w") as f:
+        with open(args.csv, "w", encoding='utf-8') as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             for idx, row in enumerate(locations):


### PR DESCRIPTION
had the following error, but it works with utf-8 encoding 

File "C:\Python311\Lib\site-packages\instagram_locations\instagram_locations.py", line 229, in main
    writer.writerow(row)
  File "C:\Python311\Lib\csv.py", line 154, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2764' in position 17: character maps to <undefined>