### PR TITLE
Fix cookie workflow

### DIFF
--- a/instagram_locations/instagram_locations.py
+++ b/instagram_locations/instagram_locations.py
@@ -10,7 +10,7 @@ from string import Template
 from time import sleep
 
 import requests
-
+import pathlib 
 
 # gets instagram "locations" around a particular lat/lng using internal API
 #   (requires session cookie for authentication)
@@ -123,9 +123,10 @@ def get_insta_cookies():
     Attempts to run selenium, provide user with the login form and extract cookies from page to be used in program.
     Returns cookies formatted as name=value;name=value;...
      """
+    path = str(pathlib.Path.home() / ".instagram_location_searcher" / "data")
     options = webdriver.ChromeOptions()
-    options.add_argument(r"--user-data-dir=~/.instagram_location_searcher/data")
-    options.add_argument(r'--profile-directory=~/.instagram_location_searcher/profile')
+    options.add_argument(f"user-data-dir={path}")
+    options.add_argument(f"profile-directory=profile")
     driver = webdriver.Chrome(options=options, service=ChromiumService(ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()))
     driver.get("https://www.instagram.com/")
     # Check that there is cookie with name sessionid (mean we logged in)

--- a/instagram_locations/instagram_locations.py
+++ b/instagram_locations/instagram_locations.py
@@ -127,7 +127,7 @@ def get_insta_cookies():
     options = webdriver.ChromeOptions()
     options.add_argument(f"user-data-dir={path}")
     options.add_argument(f"profile-directory=profile")
-    driver = webdriver.Chrome(options=options, service=ChromiumService(ChromeDriverManager(chrome_type=ChromeType.CHROMIUM).install()))
+    driver = webdriver.Chrome(options=options, service=ChromiumService(ChromeDriverManager(chrome_type=ChromeType.GOOGLE).install()))
     driver.get("https://www.instagram.com/")
     # Check that there is cookie with name sessionid (mean we logged in)
     cookies = driver.get_cookies()


### PR DESCRIPTION
Closes #23 

This PR makes some of the path handling safer for cross-platform use with `pathlib`

It also changes the `ChromeDriverManager` to use `ChromeType.GOOGLE`, as I expect this will have wider use than `ChromeType.CHROMIUM`. This choice affects the [paths used to identify the browser version](https://github.com/SergeyPirogov/webdriver_manager/blob/8eba22bc570ae5d7e4d0ed429dc6bbfc7377d4e4/webdriver_manager/core/os_manager.py#L67) when building the webdriver. This should be tested on a Mac with a standard install.

Alternatively, we could implement a browser argument with something similar to: https://github.com/bellingcat/EDGAR/blob/55270540cbb5ecab1237a8375b19efc6831e7f49/edgar_tool/browser.py